### PR TITLE
This is mangling the data on the second try

### DIFF
--- a/smartdc/datacenter.py
+++ b/smartdc/datacenter.py
@@ -207,15 +207,17 @@ class DataCenter(object):
         request_headers.update(self.default_headers)
         if headers:
             request_headers.update(headers)
+        jdata = None
         if data:
-            data = json.dumps(data)
-            kwargs['data'] = data
+            jdata = json.dumps(data)
         resp = requests.request(method, full_path, auth=self.auth, 
-            headers=request_headers, config=self.config, **kwargs)
+            headers=request_headers, config=self.config, data=jdata,
+            **kwargs)
         if (resp.status_code == 401 and self.auth and 
                 self.auth.signer._agent_key):
             self.auth.signer.swap_keys()
-            return self.request(method, path, headers=headers, **kwargs)
+            return self.request(method, path, headers=headers, data=data,
+                **kwargs)
         if 400 <= resp.status_code < 499:
             if resp.content:
                 print >> sys.stderr, resp.content


### PR DESCRIPTION
If I am reading this right, the whole point is to try every key in
your ssh-agent recursively before giving up, however, the data param
is getting mangled on the second try. I am trying to pass the same
parameters as they came in the original request, just using the next
key in the ssh-agent.

To test failure: before applying this patch, make your smartdc key
be the 2nd or 3rd in your ssh-agent, then try to create a new
machine.

After applying this patch, in theory it should be a no-op since the
status won't be 401 and the recursive call won't get triggered.
